### PR TITLE
Add basic software emulator for Aurora core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ eval/.ipynb_checkpoints
 *.protoinst
 *.wdb
 *.wcfg
+build

--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -32,7 +32,6 @@ FetchContent_GetProperties(extern_hlslib)
 if(NOT extern_hlslib_POPULATED)
   message(STATUS "Fetching mandatory build dependency hlslib")
   FetchContent_Populate(extern_hlslib)
-  set(extern_hlslib_SOURCE_DIR ${extern_hlslib_SOURCE_DIR})
     add_subdirectory(
     ${extern_hlslib_SOURCE_DIR} 
     ${extern_hlslib_BINARY_DIR} 
@@ -50,7 +49,23 @@ FetchContent_GetProperties(extern_hlslib)
 if(NOT extern_cppzmq_POPULATED)
   message(STATUS "Fetching mandatory build dependency cppzmq")
   FetchContent_Populate(extern_cppzmq)
-  set(extern_cpp_zmq_SOURCE_DIR ${extern_cppzmq_SOURCE_DIR})
+endif()
+
+
+if (NOT Vitis_FOUND)
+FetchContent_Declare(
+  extern_hlsheaders
+
+  # unfortunately they do not use releases, so the latest commit was used
+  GIT_REPOSITORY      https://github.com/quetric/hls_sim_headers.git
+  GIT_TAG             main)
+
+FetchContent_GetProperties(extern_hlsheaders)
+if(NOT extern_hlsheaders_POPULATED)
+  message(STATUS "Fetching mandatory build dependency HLS headers")
+  FetchContent_Populate(extern_hlsheaders)
+  set(extern_hlsheaders_SOURCE_DIR ${extern_hlsheaders_SOURCE_DIR}/include)
+endif()
 endif()
 
 ## use this to globally use C++11 with in our project
@@ -59,6 +74,6 @@ set(CMAKE_CXX_STANDARD 11)
 add_library(auroraemu INTERFACE)
 
 ## add the include directory to our compile directives
-target_include_directories(auroraemu INTERFACE ${extern_cppzmq_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(auroraemu INTERFACE ${extern_hlsheaders_SOURCE_DIR} ${extern_cppzmq_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/include)
 ## at the 0mq library to our link directive
 target_link_libraries(auroraemu INTERFACE zmq hlslib)

--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -1,0 +1,64 @@
+# 
+#  Copyright 2024 Marius Meyer
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# 
+cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
+project(AuroraEmuLib)
+
+include(FetchContent)
+
+# ------------------------------------------------------------------------------
+# A library that provides helper classes for the development of HLS codes.
+# This benchmark suite uses only the CMake files to find the Intel and Vitis installations
+FetchContent_Declare(
+  extern_hlslib
+
+  # unfortunately they do not use releases, so the latest commit was used
+  GIT_REPOSITORY      https://github.com/definelicht/hlslib.git
+  GIT_TAG             master)
+
+FetchContent_GetProperties(extern_hlslib)
+if(NOT extern_hlslib_POPULATED)
+  message(STATUS "Fetching mandatory build dependency hlslib")
+  FetchContent_Populate(extern_hlslib)
+  set(extern_hlslib_SOURCE_DIR ${extern_hlslib_SOURCE_DIR})
+    add_subdirectory(
+    ${extern_hlslib_SOURCE_DIR} 
+    ${extern_hlslib_BINARY_DIR} 
+    EXCLUDE_FROM_ALL)
+endif()
+
+FetchContent_Declare(
+  extern_cppzmq
+
+  # unfortunately they do not use releases, so the latest commit was used
+  GIT_REPOSITORY      https://github.com/zeromq/cppzmq.git
+  GIT_TAG             v4.10.0)
+
+FetchContent_GetProperties(extern_hlslib)
+if(NOT extern_cppzmq_POPULATED)
+  message(STATUS "Fetching mandatory build dependency cppzmq")
+  FetchContent_Populate(extern_cppzmq)
+  set(extern_cpp_zmq_SOURCE_DIR ${extern_cppzmq_SOURCE_DIR})
+endif()
+
+## use this to globally use C++11 with in our project
+set(CMAKE_CXX_STANDARD 11)
+
+add_library(auroraemu INTERFACE)
+
+## add the include directory to our compile directives
+target_include_directories(auroraemu INTERFACE ${extern_cppzmq_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/include)
+## at the 0mq library to our link directive
+target_link_libraries(auroraemu INTERFACE zmq hlslib)

--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -14,7 +14,7 @@
 #  limitations under the License.
 # 
 cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
-project(AuroraEmuLib)
+project(AuroraEmuLib VERSION 0.1)
 
 include(FetchContent)
 

--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -68,12 +68,29 @@ if(NOT extern_hlsheaders_POPULATED)
 endif()
 endif()
 
+## load in pkg-config support
+find_package(PkgConfig)
+## use pkg-config to get hints for 0mq locations
+pkg_check_modules(PC_ZeroMQ QUIET zmq)
+
+## use the hint from above to find where 'zmq.hpp' is located
+find_path(ZeroMQ_INCLUDE_DIR
+        NAMES zmq.h
+        PATHS ${PC_ZeroMQ_INCLUDE_DIRS}
+        )
+
+## use the hint from above to find the location of libzmq
+find_library(ZeroMQ_LIBRARY
+  NAMES zmq
+  PATHS ${PC_ZeroMQ_LIBRARY_DIRS}
+)
+
 ## use this to globally use C++11 with in our project
 set(CMAKE_CXX_STANDARD 11)
 
 add_library(auroraemu INTERFACE)
 
 ## add the include directory to our compile directives
-target_include_directories(auroraemu INTERFACE ${extern_hlsheaders_SOURCE_DIR} ${extern_cppzmq_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(auroraemu INTERFACE ${ZeroMQ_INCLUDE_DIR} ${extern_hlsheaders_SOURCE_DIR} ${extern_cppzmq_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/include)
 ## at the 0mq library to our link directive
-target_link_libraries(auroraemu INTERFACE zmq hlslib)
+target_link_libraries(auroraemu INTERFACE ${ZeroMQ_LIBRARY} hlslib)

--- a/emulation/CMakeLists.txt
+++ b/emulation/CMakeLists.txt
@@ -41,7 +41,6 @@ endif()
 FetchContent_Declare(
   extern_cppzmq
 
-  # unfortunately they do not use releases, so the latest commit was used
   GIT_REPOSITORY      https://github.com/zeromq/cppzmq.git
   GIT_TAG             v4.10.0)
 
@@ -68,29 +67,27 @@ if(NOT extern_hlsheaders_POPULATED)
 endif()
 endif()
 
-## load in pkg-config support
+# load in pkg-config support
 find_package(PkgConfig)
-## use pkg-config to get hints for 0mq locations
+# use pkg-config to get hints for 0mq locations
 pkg_check_modules(PC_ZeroMQ QUIET zmq)
 
-## use the hint from above to find where 'zmq.hpp' is located
+# use the hint from above to find where 'zmq.h' is located
 find_path(ZeroMQ_INCLUDE_DIR
         NAMES zmq.h
         PATHS ${PC_ZeroMQ_INCLUDE_DIRS}
         )
 
-## use the hint from above to find the location of libzmq
+# use the hint from above to find the location of libzmq
 find_library(ZeroMQ_LIBRARY
   NAMES zmq
   PATHS ${PC_ZeroMQ_LIBRARY_DIRS}
 )
 
-## use this to globally use C++11 with in our project
+# use this to globally use C++11 with in our project
 set(CMAKE_CXX_STANDARD 11)
 
 add_library(auroraemu INTERFACE)
 
-## add the include directory to our compile directives
 target_include_directories(auroraemu INTERFACE ${ZeroMQ_INCLUDE_DIR} ${extern_hlsheaders_SOURCE_DIR} ${extern_cppzmq_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/include)
-## at the 0mq library to our link directive
 target_link_libraries(auroraemu INTERFACE ${ZeroMQ_LIBRARY} hlslib)

--- a/emulation/README.md
+++ b/emulation/README.md
@@ -7,7 +7,6 @@ This is a simple Aurora emulator based on ZMQ that allows emulation of desings u
 
 The following dependencies have to be installed:
 
-- Vitis HLS (for the AXI stream and ap_int header files)
 - ZMQ
 - CMake > 3.11
 
@@ -15,6 +14,10 @@ The following dependencies are downloaded automatically:
 
 - hlslib
 - cppzmq
+
+optional dependencies:
+
+- Vitis HLS (for the AXI stream and ap_int header files. Header-only repo will be used otherwise)
 
 ## How To
 

--- a/emulation/README.md
+++ b/emulation/README.md
@@ -27,6 +27,7 @@ The emulator consist of two classes that communicate via TCP and are compatible 
 - `AuroraEmuSwitch`: Used to connect `AuroraEmuCore`s and route the data to the specified destinations.
 
 `hlslib::Stream` is used to emulate AXI streams.
+The following example shows how to connect two Aurora cores via a switch.
 
 ```{c++}
 // create AXI input and output streams for the aurora cores
@@ -37,6 +38,17 @@ auto s = AuroraEmuSwitch("127.0.0.1", 20000);
 // create and connect core to switch and set own identifiers and 
 // input and output streams
 auto a1 = AuroraEmuCore("127.0.0.1", 20000, "a1", "a2", in1, out1);
+auto a2 = AuroraEmuCore("127.0.0.1", 20000, "a2", "a1", in1, out1);
 ```
 
 The library is header only. To see how it can be used take a look into the `example` or `test` directories.
+
+## Limitations / Implementation Details
+
+The emulator may show different behavior compared to an Aurora HLS hardware implementation which has to be taken into account when testing designs:
+
+- The emulator uses the ZMQ publisher/subscriber pattern. Aurora cores subscribe to an ID on the switch and will receive all messages tagged with this ID. Multiple Aurora cores can be subscribed to the same ID and all cores will receive all messages sent to this ID.
+- The emulator does not implement back pressure, so the Aurora core is always ready to send and the data will be buffered by ZMQ if the RX FIFO is full. No data will get lost in these situations.
+- Data may get lost if it is sent before the recipient has completed the subscription to its ID.
+- Data is transferred in small messages of the size of the stream width, which may introduce some overhead.
+- The Aurora cores use active polling on the TX stream because it is not possible to provide a timeout for the read command. Sleep intervals defined by the constant `RECV_POLL_INTERVAL` are used as a tradeoff between communication latency and CPU load.

--- a/emulation/README.md
+++ b/emulation/README.md
@@ -1,0 +1,39 @@
+# Aurora Emulator based on ZMQ
+
+This is a simple Aurora emulator based on ZMQ that allows emulation of desings using the Aurora cores on the CPU.
+
+
+## Build
+
+The following dependencies have to be installed:
+
+- Vitis HLS (for the AXI stream and ap_int header files)
+- ZMQ
+- CMake > 3.11
+
+The following dependencies are downloaded automatically:
+
+- hlslib
+- cppzmq
+
+## How To
+
+The emulator consist of two classes that communicate via TCP and are compatible with MPI:
+
+- `AuroraEmuCore`: Emulated Aurora core that has to be connected to a `AuroraEmuSwitch` to route data.
+- `AuroraEmuSwitch`: Used to connect `AuroraEmuCore`s and route the data to the specified destinations.
+
+`hlslib::Stream` is used to emulate AXI streams.
+
+```{c++}
+// create AXI input and output streams for the aurora cores
+hlslib::Stream<data_stream_t> in1("in1"), out1("out1"), in2("in2"),
+    out2("out2");
+// Create an aurora switch
+auto s = AuroraEmuSwitch("127.0.0.1", 20000);
+// create and connect core to switch and set own identifiers and 
+// input and output streams
+auto a1 = AuroraEmuCore("127.0.0.1", 20000, "a1", "a2", in1, out1);
+```
+
+The library is header only. To see how it can be used take a look into the `example` or `test` directories.

--- a/emulation/example/CMakeLists.txt
+++ b/emulation/example/CMakeLists.txt
@@ -1,0 +1,25 @@
+# 
+#  Copyright 2024 Marius Meyer
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# 
+cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
+project(AuroraEmuExample)
+
+add_subdirectory(${CMAKE_SOURCE_DIR}/.. ${CMAKE_BINARY_DIR}/auroraemu)
+
+set(KERNEL_FILES ${CMAKE_SOURCE_DIR}/collector.cpp ${CMAKE_SOURCE_DIR}/vadd_kernel.cpp)
+set(SOURCE_FILES ${CMAKE_SOURCE_DIR}/main.cpp )
+add_executable(aurora_emu_example ${SOURCE_FILES} ${KERNEL_FILES})
+
+target_link_libraries(aurora_emu_example PUBLIC auroraemu)

--- a/emulation/example/CMakeLists.txt
+++ b/emulation/example/CMakeLists.txt
@@ -15,6 +15,7 @@
 # 
 cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
 project(AuroraEmuExample)
+set(CMAKE_CXX_STANDARD 11)
 
 add_subdirectory(${CMAKE_SOURCE_DIR}/.. ${CMAKE_BINARY_DIR}/auroraemu)
 

--- a/emulation/example/README.md
+++ b/emulation/example/README.md
@@ -1,0 +1,29 @@
+# Aurora Emu Example
+
+Minimal example to show how to use the Aurora emulator.
+We send a vector to a kernel on a remote FPGA using Aurora and add calculate the sum with another vector.
+The result is sent back to the local kernel.
+
+This example code consists of two HLS kernels:
+
+- `remote_vadd`: Retrieves data from the aurora core and adds data from a local vector to it. Writes the results back to the aurora core.
+- `collector`: read data from a local vector and write it to the aurora core. Read data back from the aurora core and write it into a result vector.
+
+## Build
+
+The following dependencies have to be installed:
+
+- Vitis HLS (for the AXI stream and ap_int header files)
+- ZMQ
+- CMake > 3.11
+
+To build with cmake:
+
+    mkdir build
+    cd build
+    cmake ..
+    make
+
+To execute the example:
+
+    ./aurora_emu_example

--- a/emulation/example/README.md
+++ b/emulation/example/README.md
@@ -11,11 +11,7 @@ This example code consists of two HLS kernels:
 
 ## Build
 
-The following dependencies have to be installed:
-
-- Vitis HLS (for the AXI stream and ap_int header files)
-- ZMQ
-- CMake > 3.11
+The Aurora Emu dependencies have to be installed.
 
 To build with cmake:
 

--- a/emulation/example/collector.cpp
+++ b/emulation/example/collector.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Marius Meyer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernels.h"
+
+void collector(float* data_in, float* data_out, size_t data_size,
+               STREAM<data_stream_t>& from_remote,
+               STREAM<data_stream_t>& to_remote) {
+    for (size_t i = 0; i < data_size; i += 16) {
+#pragma HLS pipeline II = 1
+        // get data from local memory buffer
+        ap_uint_to_floats_t remote_conv;
+        for (size_t ii = 0; ii < 16; ii++) {
+            remote_conv.data[ii] = data_in[i + ii];
+        }
+        // send data to remote via aurora
+        data_stream_t out;
+        out.data = remote_conv.stream_data;
+        to_remote.write(out);
+        // get remote data from aurora core
+        remote_conv.stream_data = from_remote.read().data;
+        for (int ii = 0; ii < 16; ii++) {
+            data_out[i + ii] = remote_conv.data[ii];
+        }
+    }
+}

--- a/emulation/example/common_streams.h
+++ b/emulation/example/common_streams.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Marius Meyer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SYNTHESIS
+#include "hlslib/xilinx/Stream.h"
+#define STREAM hlslib::Stream
+#else
+#include "hls_streams.h"
+#define STREAM hls::stream
+#endif
+
+typedef union ap_uint_to_floats {
+    ap_uint_to_floats(){};
+    ~ap_uint_to_floats(){};
+    float data[16];
+    ap_uint<512> stream_data;
+} ap_uint_to_floats_t;

--- a/emulation/example/kernels.h
+++ b/emulation/example/kernels.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Marius Meyer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ap_axi_sdata.h>
+#include <ap_int.h>
+
+#include "common_streams.h"
+
+typedef ap_axiu<512, 0, 0, 0> data_stream_t;
+
+void remote_vadd(float* data, size_t data_size,
+                 STREAM<data_stream_t>& from_remote,
+                 STREAM<data_stream_t>& to_remote);
+
+void collector(float* data_in, float* data_out, size_t data_size,
+               STREAM<data_stream_t>& from_remote,
+               STREAM<data_stream_t>& to_remote);

--- a/emulation/example/main.cpp
+++ b/emulation/example/main.cpp
@@ -26,12 +26,12 @@ int main() {
     hlslib::Stream<data_stream_t> in1("in1"), out1("out1"), in2("in2"),
         out2("out2");
     // Create an aurora switch
-    auto s = AuroraEmuSwitch("127.0.0.1", 20000);
+    AuroraEmuSwitch s("127.0.0.1", 20000);
     // create emulated aurora cores
     // connect cores to switch and set own identifier and identifier of
     // remote core
-    auto a1 = AuroraEmuCore("127.0.0.1", 20000, "a1", "a2", in1, out1);
-    auto a2 = AuroraEmuCore("127.0.0.1", 20000, "a2", "a1", in2, out2);
+    AuroraEmuCore a1("127.0.0.1", 20000, "a1", "a2", in1, out1);
+    AuroraEmuCore a2("127.0.0.1", 20000, "a2", "a1", in2, out2);
 
     // create some input data
     float data_in[64];

--- a/emulation/example/main.cpp
+++ b/emulation/example/main.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Marius Meyer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include <thread>
+
+#include "auroraemu.hpp"
+#include "hlslib/xilinx/Stream.h"
+#include "kernels.h"
+
+int main() {
+    // create AXI input and output axi streams for the aurora cores
+    hlslib::Stream<data_stream_t> in1("in1"), out1("out1"), in2("in2"),
+        out2("out2");
+    // Create an aurora switch
+    auto s = AuroraEmuSwitch("127.0.0.1", 20000);
+    // create emulated aurora cores
+    // connect cores to switch and set own identifier and identifier of
+    // remote core
+    auto a1 = AuroraEmuCore("127.0.0.1", 20000, "a1", "a2", in1, out1);
+    auto a2 = AuroraEmuCore("127.0.0.1", 20000, "a2", "a1", in2, out2);
+
+    // create some input data
+    float data_in[64];
+    float data_out[64];
+    for (int i = 0; i < 64; i++) {
+        data_in[i] = i;
+        data_out[i] = 0;
+    }
+
+    // Start the vadd kernel on the remote FPGA
+    std::thread remote_kernel(remote_vadd, data_in, 64, std::ref(out2),
+                              std::ref(in2));
+    // start the collector kernel locally
+    collector(data_in, data_out, 64, out1, in1);
+    remote_kernel.join();
+
+    // validate result and print absolute error
+    float error = 0.0;
+    for (int i = 0; i < 64; i++) {
+        error += std::abs(data_in[i] * 2 - data_out[i]);
+    }
+    std::cout << "Absolute error " << error << std::endl;
+}

--- a/emulation/example/vadd_kernel.cpp
+++ b/emulation/example/vadd_kernel.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Marius Meyer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernels.h"
+
+void remote_vadd(float *data, size_t data_size,
+                 STREAM<data_stream_t> &from_remote,
+                 STREAM<data_stream_t> &to_remote) {
+    for (size_t i = 0; i < data_size; i += 16) {
+#pragma HLS pipeline II = 1
+        // get data from local memory buffer
+        float local_in[16];
+        for (size_t ii = 0; ii < 16; ii++) {
+            local_in[ii] = data[i + ii];
+        }
+        // get remote data from aurora core
+        ap_uint_to_floats_t remote_conv;
+        remote_conv.stream_data = from_remote.read().data;
+        for (int ii = 0; ii < 16; ii++) {
+            remote_conv.data[ii] += local_in[ii];
+        }
+        // send result to remote via aurora
+        data_stream_t out;
+        out.data = remote_conv.stream_data;
+        to_remote.write(out);
+    }
+}

--- a/emulation/include/auroraemu.hpp
+++ b/emulation/include/auroraemu.hpp
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2024 Marius Meyer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <ap_axi_sdata.h>
+#include <ap_int.h>
+#include <hlslib/xilinx/Stream.h>
+
+#include <iostream>
+#include <thread>
+#include <zmq.hpp>
+
+typedef ap_axiu<512, 0, 0, 0> data_stream_t;
+
+const int RECV_POLL_INTERVAL = 100;
+
+class AuroraEmu {
+   private:
+    // ZMQ sockets used to exchange data between Aurroa cores
+    zmq::context_t ctx;
+    zmq::socket_t sock_out;
+    zmq::socket_t sock_in;
+
+    // ZMQ socket used to terminate send and recv threads
+    zmq::socket_t kill_socket;
+
+    // send and recv threads used to pass data to and from user kernels
+    std::thread recv_thread;
+    std::thread send_thread;
+
+    // streams used to pass data to and from user kernels
+    hlslib::Stream<data_stream_t> &remote_to_user;
+    hlslib::Stream<data_stream_t> &user_to_remote;
+
+    // id that is used to name the socket of the aurora emulator
+    // or the network port
+    std::string id;
+    std::string protocol;
+
+    void forward_from_remote() {
+        zmq::socket_t kill_listener(ctx, zmq::socket_type::sub);
+        kill_listener.connect("inproc://kill_" + id);
+        kill_listener.set(zmq::sockopt::subscribe, "");
+        zmq::message_t msg;
+        // listen to kill singals and data comming in
+        zmq::pollitem_t items[] = {{sock_in, 0, ZMQ_POLLIN, 0},
+                                   {kill_listener, 0, ZMQ_POLLIN, 0}};
+        while (true) {
+            zmq::poll(&items[0], 2);
+            if (items[0].revents & ZMQ_POLLIN) {
+                auto result = sock_in.recv(msg, zmq::recv_flags::none);
+                data_stream_t data;
+                data.data = *static_cast<ap_uint<512> *>(msg.data());
+                remote_to_user.write(data);
+            }
+            if (items[1].revents & ZMQ_POLLIN) {
+                break;
+            }
+        }
+    }
+
+    void forward_from_user() {
+        zmq::socket_t kill_listener(ctx, zmq::socket_type::sub);
+        kill_listener.connect("inproc://kill_" + id);
+        kill_listener.set(zmq::sockopt::subscribe, "");
+        while (true) {
+            // check if stream is empty. If so, sleep a bit to reduce CPU load
+            while (user_to_remote.empty()) {
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(RECV_POLL_INTERVAL));
+                // check for kill signals in between
+                zmq::message_t m;
+                if (kill_listener.recv(m, zmq::recv_flags::dontwait)
+                        .has_value()) {
+                    return;
+                }
+            }
+            // forward incoming data to user kernel
+            ap_uint<512> data = user_to_remote.read().data;
+            zmq::message_t msg(static_cast<void *>(&data),
+                               sizeof(ap_uint<512>));
+            sock_out.send(msg, zmq::send_flags::none);
+        }
+    }
+
+   public:
+    AuroraEmu(std::string host_address, int port,
+              hlslib::Stream<data_stream_t> &user_to_remote,
+              hlslib::Stream<data_stream_t> &remote_to_user)
+        : ctx(1),
+          sock_out(ctx, zmq::socket_type::pub),
+          sock_in(ctx, zmq::socket_type::sub),
+          kill_socket(ctx, zmq::socket_type::pub),
+          user_to_remote(user_to_remote),
+          remote_to_user(remote_to_user),
+          id(host_address + ":" + std::to_string(port)),
+          protocol("tcp") {
+        sock_out.bind(protocol + "://" + id);
+        kill_socket.bind("inproc://kill_" + id);
+    }
+
+    AuroraEmu(std::string pipe_name,
+              hlslib::Stream<data_stream_t> &user_to_remote,
+              hlslib::Stream<data_stream_t> &remote_to_user)
+        : ctx(1),
+          sock_out(ctx, zmq::socket_type::pub),
+          sock_in(ctx, zmq::socket_type::sub),
+          kill_socket(ctx, zmq::socket_type::pub),
+          user_to_remote(user_to_remote),
+          remote_to_user(remote_to_user),
+          id(pipe_name),
+          protocol("ipc") {
+        sock_out.bind(protocol + "://" + id);
+        kill_socket.bind("inproc://kill_" + id);
+    }
+
+    ~AuroraEmu() {
+        // send kill signal to all threads
+        // and wait for them to join
+        zmq::message_t t(0);
+        kill_socket.send(t, zmq::send_flags::none);
+        if (recv_thread.joinable()) {
+            recv_thread.join();
+        }
+        if (send_thread.joinable()) {
+            send_thread.join();
+        }
+    }
+
+    void connect(AuroraEmu &other_core, bool bidirectional = true) {
+        if ((get_address() != other_core.get_address()) && bidirectional)
+            other_core.connect(*this, false);
+        sock_in.connect(other_core.get_address());
+        sock_in.set(zmq::sockopt::subscribe, "");
+        std::thread t1(&AuroraEmu::forward_from_remote, this);
+        std::thread t2(&AuroraEmu::forward_from_user, this);
+        recv_thread.swap(t1);
+        send_thread.swap(t2);
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(RECV_POLL_INTERVAL));
+    }
+
+    std::string get_address() { return protocol + "://" + id; }
+};
+
+class AuroraEmuSwitch {
+   private:
+    // ZMQ sockets used to exchange data between Aurroa cores
+    zmq::context_t ctx;
+    zmq::socket_t distributor;
+    zmq::socket_t incomming;
+
+    // ZMQ socket used to terminate send and recv threads
+    zmq::socket_t kill_socket;
+
+    // send and recv threads used to pass data to and from user kernels
+    std::thread switch_thread;
+
+    // ZMQ address of the kill socket for this switch
+    std::string kill_id;
+
+    void forward_data() {
+        zmq::socket_t kill_listener(ctx, zmq::socket_type::sub);
+        kill_listener.connect(kill_id);
+        kill_listener.set(zmq::sockopt::subscribe, "");
+        zmq::message_t msg;
+        // listen to kill singals and data comming in
+        zmq::pollitem_t items[] = {{incomming, 0, ZMQ_POLLIN, 0},
+                                   {kill_listener, 0, ZMQ_POLLIN, 0}};
+        while (true) {
+            zmq::poll(&items[0], 2);
+            if (items[0].revents & ZMQ_POLLIN) {
+                // forward topic
+                auto result = incomming.recv(msg, zmq::recv_flags::none);
+                distributor.send(msg, zmq::send_flags::sndmore);
+                // forward content
+                result = incomming.recv(msg, zmq::recv_flags::none);
+                distributor.send(msg, zmq::send_flags::none);
+            }
+            if (items[1].revents & ZMQ_POLLIN) {
+                break;
+            }
+        }
+    }
+
+   public:
+    /**
+     * Construct and connect a new aurora switch
+     *
+     * host_address: IP address or name of the host machine
+     * port: Port of the aurora switch. port and port+1 will be used to
+     *      establish the switch functionality.
+     */
+    AuroraEmuSwitch(std::string host_address, int port)
+        : ctx(1),
+          incomming(ctx, zmq::socket_type::pull),
+          distributor(ctx, zmq::socket_type::pub),
+          kill_socket(ctx, zmq::socket_type::pub),
+          kill_id("inproc://kill_" + host_address + "_" +
+                  std::to_string(port)) {
+        incomming.bind("tcp://" + host_address + ":" + std::to_string(port));
+        distributor.bind("tcp://" + host_address + ":" +
+                         std::to_string(port + 1));
+        kill_socket.bind(kill_id);
+        switch_thread = std::thread(&AuroraEmuSwitch::forward_data, this);
+    }
+
+    ~AuroraEmuSwitch() {
+        // send kill signal to all threads
+        // and wait for them to join
+        zmq::message_t t(0);
+        kill_socket.send(t, zmq::send_flags::none);
+        if (switch_thread.joinable()) {
+            switch_thread.join();
+        }
+    }
+};
+
+class AuroraEmuCore {
+   private:
+    // ZMQ sockets used to exchange data between Aurroa cores
+    zmq::context_t ctx;
+    zmq::socket_t to_switch;
+    zmq::socket_t from_switch;
+
+    // ZMQ socket used to terminate send and recv threads
+    zmq::socket_t kill_socket;
+
+    // send and recv threads used to pass data to and from user kernels
+    std::thread recv_thread;
+    std::thread send_thread;
+
+    // streams used to pass data to and from user kernels
+    hlslib::Stream<data_stream_t> &remote_to_user;
+    hlslib::Stream<data_stream_t> &user_to_remote;
+
+    // id that is used to name the socket of the aurora emulator
+    // or the network port
+    std::string id;
+    std::string remote_id;
+
+    void forward_from_remote() {
+        zmq::socket_t kill_listener(ctx, zmq::socket_type::sub);
+        kill_listener.connect("inproc://kill_" + id);
+        kill_listener.set(zmq::sockopt::subscribe, "");
+        zmq::message_t msg;
+        // listen to kill singals and data comming in
+        zmq::pollitem_t items[] = {{from_switch, 0, ZMQ_POLLIN, 0},
+                                   {kill_listener, 0, ZMQ_POLLIN, 0}};
+        while (true) {
+            zmq::poll(&items[0], 2);
+            if (items[0].revents & ZMQ_POLLIN) {
+                // receive aurora id of incoming message. Discard
+                auto result = from_switch.recv(msg, zmq::recv_flags::none);
+                // receive actual message
+                result = from_switch.recv(msg, zmq::recv_flags::none);
+                data_stream_t data;
+                data.data = *static_cast<ap_uint<512> *>(msg.data());
+                remote_to_user.write(data);
+            }
+            if (items[1].revents & ZMQ_POLLIN) {
+                break;
+            }
+        }
+    }
+
+    void forward_from_user() {
+        zmq::socket_t kill_listener(ctx, zmq::socket_type::sub);
+        kill_listener.connect("inproc://kill_" + id);
+        kill_listener.set(zmq::sockopt::subscribe, "");
+        while (true) {
+            // check if stream is empty. If so, sleep a bit to reduce CPU load
+            while (user_to_remote.empty()) {
+                std::this_thread::sleep_for(
+                    std::chrono::milliseconds(RECV_POLL_INTERVAL));
+                // check for kill signals in between
+                zmq::message_t m;
+                if (kill_listener.recv(m, zmq::recv_flags::dontwait)
+                        .has_value()) {
+                    return;
+                }
+            }
+            // forward incoming data to user kernel
+            ap_uint<512> data = user_to_remote.read().data;
+            zmq::message_t msg(static_cast<void *>(&data),
+                               sizeof(ap_uint<512>));
+            zmq::message_t a_id(remote_id);
+            to_switch.send(a_id, zmq::send_flags::sndmore);
+            to_switch.send(msg, zmq::send_flags::none);
+        }
+    }
+
+   public:
+    /**
+     * Construct and connect a new aurora core
+     *
+     * switch_address: IP address or name of the host machine the switch is
+     *                  running on
+     * switch_port: Port of the aurora switch id: own ID of the
+     *              aurora core. Must be a unique string
+     * remote_id: ID of the aurora core to connect to
+     * user_to_remote: AXI stream to pass data into the aurora core
+     * remote_to_user: AXI stream to read data from the aurora core
+     */
+    AuroraEmuCore(std::string switch_address, int switch_port, std::string id,
+                  std::string remote_id,
+                  hlslib::Stream<data_stream_t> &user_to_remote,
+                  hlslib::Stream<data_stream_t> &remote_to_user)
+        : ctx(1),
+          to_switch(ctx, zmq::socket_type::push),
+          from_switch(ctx, zmq::socket_type::sub),
+          kill_socket(ctx, zmq::socket_type::pub),
+          user_to_remote(user_to_remote),
+          remote_to_user(remote_to_user),
+          id(id),
+          remote_id(remote_id) {
+        kill_socket.bind("inproc://kill_" + id);
+        to_switch.connect("tcp://" + switch_address + ":" +
+                          std::to_string(switch_port));
+        from_switch.connect("tcp://" + switch_address + ":" +
+                            std::to_string(switch_port + 1));
+        from_switch.set(zmq::sockopt::subscribe, id);
+        std::thread t1(&AuroraEmuCore::forward_from_remote, this);
+        std::thread t2(&AuroraEmuCore::forward_from_user, this);
+        recv_thread.swap(t1);
+        send_thread.swap(t2);
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(RECV_POLL_INTERVAL));
+    }
+
+    ~AuroraEmuCore() {
+        // send kill signal to all threads
+        // and wait for them to join
+        zmq::message_t t(0);
+        kill_socket.send(t, zmq::send_flags::none);
+        if (recv_thread.joinable()) {
+            recv_thread.join();
+        }
+        if (send_thread.joinable()) {
+            send_thread.join();
+        }
+    }
+};

--- a/emulation/test/CMakeLists.txt
+++ b/emulation/test/CMakeLists.txt
@@ -1,0 +1,45 @@
+# 
+#  Copyright 2024 Marius Meyer
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# 
+cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
+project(AuroraEmuLibTest)
+
+add_subdirectory(${CMAKE_SOURCE_DIR}/.. ${CMAKE_BINARY_DIR}/auroraemu)
+
+include(FetchContent)
+
+# ------------------------------------------------------------------------------
+# A unit testing suite for C++
+FetchContent_Declare(
+  extern_googletest
+
+  DOWNLOAD_EXTRACT_TIMESTAMP Yes
+  URL      https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+  URL_HASH SHA256=8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7)
+
+FetchContent_GetProperties(extern_googletest)
+if(NOT extern_googletest_POPULATED)
+  message(STATUS "Fetching mandatory build dependency GoogleTest")
+  FetchContent_Populate(extern_googletest)
+  add_subdirectory(
+    ${extern_googletest_SOURCE_DIR} 
+    ${extern_googletest_BINARY_DIR} 
+    EXCLUDE_FROM_ALL)
+endif()
+
+set(SOURCE_FILES ${CMAKE_SOURCE_DIR}/test.cpp)
+add_executable(aurora_emu_test ${SOURCE_FILES})
+
+target_link_libraries(aurora_emu_test PUBLIC gtest gmock auroraemu)

--- a/emulation/test/README.md
+++ b/emulation/test/README.md
@@ -1,0 +1,28 @@
+# Aurora Emulation Tests
+
+Unit tests to check the functionality of the Aurora emulator.
+
+## Build
+
+The following dependencies have to be installed:
+
+- Vitis HLS (for the AXI stream and ap_int header files)
+- ZMQ
+- CMake > 3.11
+
+The following dependencies are downloaded automatically:
+
+- hlslib
+- google_test
+
+
+To build with cmake:
+
+    mkdir build
+    cd build
+    cmake ..
+    make
+
+To execute the example:
+
+    ./aurora_emu_test

--- a/emulation/test/README.md
+++ b/emulation/test/README.md
@@ -4,15 +4,8 @@ Unit tests to check the functionality of the Aurora emulator.
 
 ## Build
 
-The following dependencies have to be installed:
+Next to the Aurora emu dependencies, the following dependencies will be built automatically:
 
-- Vitis HLS (for the AXI stream and ap_int header files)
-- ZMQ
-- CMake > 3.11
-
-The following dependencies are downloaded automatically:
-
-- hlslib
 - google_test
 
 

--- a/emulation/test/test.cpp
+++ b/emulation/test/test.cpp
@@ -119,6 +119,29 @@ TEST_F(AuroraEmuTest, SwitchConnectTwo) {
     EXPECT_TRUE(out2.empty());
 }
 
+TEST_F(AuroraEmuTest, SwitchConnectInRing) {
+    hlslib::Stream<data_stream_t> in1("in1"), out1("out1"), in2("in2"),
+        out2("out2"), in3("in3"), out3("out3"), in4("in4"), out4("out4");
+    AuroraEmuSwitch s("127.0.0.1", 20000);
+    AuroraEmuCore a1("127.0.0.1", 20000, "a1", "a2", in1, out1);
+    AuroraEmuCore a2("127.0.0.1", 20000, "a2", "a3", in2, out2);
+    AuroraEmuCore a3("127.0.0.1", 20000, "a3", "a4", in3, out3);
+    AuroraEmuCore a4("127.0.0.1", 20000, "a4", "a1", in4, out4);
+    std::cout << "Write stuff" << std::endl;
+    std::cout << "Send " << std::endl;
+    data_stream_t data;
+    data.data = ap_uint<512>(345686);
+    in1.write(data);
+    std::cout << "Forward " << std::endl;
+    in2.write(out2.read());
+    std::cout << "Forward " << std::endl;
+    in3.write(out3.read());
+    std::cout << "Forward " << std::endl;
+    in4.write(out4.read());
+    std::cout << "Check " << std::endl;
+    EXPECT_EQ(out1.read().data, ap_uint<512>(345686));
+}
+
 TEST_F(AuroraEmuTest, ConnectTwo) {
     hlslib::Stream<data_stream_t> in1("in1"), out1("out1"), in2("in2"),
         out2("out2");

--- a/emulation/test/test.cpp
+++ b/emulation/test/test.cpp
@@ -32,19 +32,19 @@ struct AuroraEmuTest : public ::testing::Test {
 
 TEST_F(AuroraEmuTest, ConstructorNamedPipes) {
     hlslib::Stream<data_stream_t> in, out;
-    auto e = AuroraEmu("hans", in, out);
+    AuroraEmu e("hans", in, out);
     EXPECT_EQ(e.get_address(), "ipc://hans");
 }
 
 TEST_F(AuroraEmuTest, ConstructorTCP) {
     hlslib::Stream<data_stream_t> in, out;
-    auto e = AuroraEmu("127.0.0.1", 20003, in, out);
+    AuroraEmu e("127.0.0.1", 20003, in, out);
     EXPECT_EQ(e.get_address(), "tcp://127.0.0.1:20003");
 }
 
 TEST_F(AuroraEmuTest, ConnectLoopback) {
     hlslib::Stream<data_stream_t> in, out;
-    auto e = AuroraEmu("hans", in, out);
+    AuroraEmu e("hans", in, out);
     e.connect(e);
 
     data_stream_t data;
@@ -55,7 +55,7 @@ TEST_F(AuroraEmuTest, ConnectLoopback) {
 }
 
 TEST_F(AuroraEmuTest, ConstructorSwitch) {
-    auto s = AuroraEmuSwitch("127.0.0.1", 20000);
+    AuroraEmuSwitch s("127.0.0.1", 20000);
     zmq::context_t ctx(1);
     zmq::socket_t to_switch(ctx, zmq::socket_type::push);
     zmq::socket_t from_switch(ctx, zmq::socket_type::sub);
@@ -84,9 +84,9 @@ TEST_F(AuroraEmuTest, ConstructorSwitch) {
 
 TEST_F(AuroraEmuTest, ConnectSwitchLoopback) {
     hlslib::Stream<data_stream_t> in, out;
-    auto s = AuroraEmuSwitch("127.0.0.1", 20000);
+    AuroraEmuSwitch s("127.0.0.1", 20000);
     std::cout << "Start core" << std::endl;
-    auto e = AuroraEmuCore("127.0.0.1", 20000, "hans", "hans", in, out);
+    AuroraEmuCore e("127.0.0.1", 20000, "hans", "hans", in, out);
     data_stream_t data;
     data.data = ap_uint<512>(7);
     std::cout << "write data" << std::endl;
@@ -99,9 +99,9 @@ TEST_F(AuroraEmuTest, ConnectSwitchLoopback) {
 TEST_F(AuroraEmuTest, SwitchConnectTwo) {
     hlslib::Stream<data_stream_t> in1("in1"), out1("out1"), in2("in2"),
         out2("out2");
-    auto s = AuroraEmuSwitch("127.0.0.1", 20000);
-    auto a1 = AuroraEmuCore("127.0.0.1", 20000, "hans", "franz", in1, out1);
-    auto a2 = AuroraEmuCore("127.0.0.1", 20000, "franz", "hans", in2, out2);
+    AuroraEmuSwitch s("127.0.0.1", 20000);
+    AuroraEmuCore a1("127.0.0.1", 20000, "hans", "franz", in1, out1);
+    AuroraEmuCore a2("127.0.0.1", 20000, "franz", "hans", in2, out2);
     std::cout << "Write stuff" << std::endl;
     for (int i = 0; i < 100; i += 10) {
         std::cout << "Send " << i << std::endl;
@@ -122,8 +122,8 @@ TEST_F(AuroraEmuTest, SwitchConnectTwo) {
 TEST_F(AuroraEmuTest, ConnectTwo) {
     hlslib::Stream<data_stream_t> in1("in1"), out1("out1"), in2("in2"),
         out2("out2");
-    auto a1 = AuroraEmu("20000", in1, out1);
-    auto a2 = AuroraEmu("20001", in2, out2);
+    AuroraEmu a1("20000", in1, out1);
+    AuroraEmu a2("20001", in2, out2);
     a1.connect(a2);
     std::cout << "Write stuff" << std::endl;
     for (int i = 0; i < 100; i += 10) {

--- a/emulation/test/test.cpp
+++ b/emulation/test/test.cpp
@@ -1,0 +1,151 @@
+#include <chrono>
+/*
+ * Copyright 2024 Marius Meyer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <iostream>
+
+#include "auroraemu.hpp"
+#include "gtest/gtest.h"
+#include "hlslib/xilinx/Stream.h"
+
+struct AuroraEmuTest : public ::testing::Test {
+    AuroraEmuTest() {
+        // Empty
+    }
+
+    void SetUp() {
+        // Empty
+    }
+};
+
+TEST_F(AuroraEmuTest, ConstructorNamedPipes) {
+    hlslib::Stream<data_stream_t> in, out;
+    auto e = AuroraEmu("hans", in, out);
+    EXPECT_EQ(e.get_address(), "ipc://hans");
+}
+
+TEST_F(AuroraEmuTest, ConstructorTCP) {
+    hlslib::Stream<data_stream_t> in, out;
+    auto e = AuroraEmu("127.0.0.1", 20003, in, out);
+    EXPECT_EQ(e.get_address(), "tcp://127.0.0.1:20003");
+}
+
+TEST_F(AuroraEmuTest, ConnectLoopback) {
+    hlslib::Stream<data_stream_t> in, out;
+    auto e = AuroraEmu("hans", in, out);
+    e.connect(e);
+
+    data_stream_t data;
+    data.data = ap_uint<512>(7);
+    in.write(data);
+    data_stream_t data2 = out.read();
+    EXPECT_EQ(data.data, data2.data);
+}
+
+TEST_F(AuroraEmuTest, ConstructorSwitch) {
+    auto s = AuroraEmuSwitch("127.0.0.1", 20000);
+    zmq::context_t ctx(1);
+    zmq::socket_t to_switch(ctx, zmq::socket_type::push);
+    zmq::socket_t from_switch(ctx, zmq::socket_type::sub);
+
+    to_switch.connect("tcp://127.0.0.1:20000");
+    from_switch.connect("tcp://127.0.0.1:20001");
+    std::string id = "test";
+    from_switch.set(zmq::sockopt::subscribe, id);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    std::string content = "hello";
+    zmq::message_t msg(content);
+    zmq::message_t a_id(id);
+    to_switch.send(a_id, zmq::send_flags::sndmore);
+    to_switch.send(msg, zmq::send_flags::none);
+
+    auto result = from_switch.recv(msg, zmq::recv_flags::none);
+    EXPECT_EQ(result.has_value(), true);
+    EXPECT_EQ(result.value(), 4);
+    EXPECT_EQ(msg.to_string(), id);
+    result = from_switch.recv(msg, zmq::recv_flags::none);
+    EXPECT_EQ(result.has_value(), true);
+    EXPECT_EQ(result.value(), 5);
+    EXPECT_EQ(msg.to_string(), content);
+}
+
+TEST_F(AuroraEmuTest, ConnectSwitchLoopback) {
+    hlslib::Stream<data_stream_t> in, out;
+    auto s = AuroraEmuSwitch("127.0.0.1", 20000);
+    std::cout << "Start core" << std::endl;
+    auto e = AuroraEmuCore("127.0.0.1", 20000, "hans", "hans", in, out);
+    data_stream_t data;
+    data.data = ap_uint<512>(7);
+    std::cout << "write data" << std::endl;
+    in.write(data);
+    std::cout << "read data" << std::endl;
+    data_stream_t data2 = out.read();
+    EXPECT_EQ(data.data, data2.data);
+}
+
+TEST_F(AuroraEmuTest, SwitchConnectTwo) {
+    hlslib::Stream<data_stream_t> in1("in1"), out1("out1"), in2("in2"),
+        out2("out2");
+    auto s = AuroraEmuSwitch("127.0.0.1", 20000);
+    auto a1 = AuroraEmuCore("127.0.0.1", 20000, "hans", "franz", in1, out1);
+    auto a2 = AuroraEmuCore("127.0.0.1", 20000, "franz", "hans", in2, out2);
+    std::cout << "Write stuff" << std::endl;
+    for (int i = 0; i < 100; i += 10) {
+        std::cout << "Send " << i << std::endl;
+        data_stream_t data;
+        data.data = ap_uint<512>(i);
+        in1.write(data);
+        std::cout << "Send back " << i << std::endl;
+        in2.write(out2.read());
+        std::cout << "Check " << i << std::endl;
+        EXPECT_EQ(out1.read().data, ap_uint<512>(i));
+    }
+    EXPECT_TRUE(in1.empty());
+    EXPECT_TRUE(in2.empty());
+    EXPECT_TRUE(out1.empty());
+    EXPECT_TRUE(out2.empty());
+}
+
+TEST_F(AuroraEmuTest, ConnectTwo) {
+    hlslib::Stream<data_stream_t> in1("in1"), out1("out1"), in2("in2"),
+        out2("out2");
+    auto a1 = AuroraEmu("20000", in1, out1);
+    auto a2 = AuroraEmu("20001", in2, out2);
+    a1.connect(a2);
+    std::cout << "Write stuff" << std::endl;
+    for (int i = 0; i < 100; i += 10) {
+        std::cout << "Send " << i << std::endl;
+        data_stream_t data;
+        data.data = ap_uint<512>(i);
+        in1.write(data);
+        std::cout << "Send back " << i << std::endl;
+        in2.write(out2.read());
+        std::cout << "Check " << i << std::endl;
+        EXPECT_EQ(out1.read().data, ap_uint<512>(i));
+    }
+    EXPECT_TRUE(in1.empty());
+    EXPECT_TRUE(in2.empty());
+    EXPECT_TRUE(out1.empty());
+    EXPECT_TRUE(out2.empty());
+}
+
+int main(int argc, char *argv[]) {
+    ::testing::InitGoogleTest(&argc, argv);
+
+    bool result = RUN_ALL_TESTS();
+
+    return result;
+}

--- a/emulation/test/test.cpp
+++ b/emulation/test/test.cpp
@@ -170,7 +170,7 @@ TEST_F(AuroraEmuTest, SwitchConcurrentTransfers) {
     t1.join();
     t2.join();
     std::cout << "Check " << std::endl;
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < 200; i++) {
         EXPECT_EQ(out2.read().data, ap_uint<512>(345686));
         EXPECT_EQ(out4.read().data, ap_uint<512>(117799));
     }


### PR DESCRIPTION
This PR targets #5 and adds the following functionality:

- A software emulator for Aurora cores based on ZMQ with support for named pipes and TCP connections
- CMake build scripts for easy integration into the host code
- Unit tests and example code how to use the emulator

This emulator is not compatible with the XRT software emulator but can be used to test the functionality of the design by compiling the kernels into the host code.
The Vitis dependency can be removed by using this HLS header collection instead: https://github.com/quetric/hls_sim_headers/

To run the tests and example on Noctua 2, load the following modules: `module load fpga xilinx/xrt lib zmqpp devel CMake `