### PR TITLE
Fix frame counter and CRC readings

### DIFF
--- a/host/host_aurora_hls_test.cpp
+++ b/host/host_aurora_hls_test.cpp
@@ -486,5 +486,8 @@ int main(int argc, char *argv[])
         }
     }
 
+    printf("Total frames received: %d\n", aurora.get_frames_received());
+    printf("Frames with errors: %d\n", aurora.get_frames_with_errors());
+
     MPI_Finalize();
 }

--- a/rtl/aurora_hls.v.template.v
+++ b/rtl/aurora_hls.v.template.v
@@ -417,8 +417,8 @@ aurora_hls_nfc aurora_hls_nfc_0 (
 );
 
 `ifdef USE_FRAMING
-wire frames_received_u;
-wire frames_with_errors_u;
+wire [31:0] frames_received_u;
+wire [31:0] frames_with_errors_u;
 
 aurora_hls_crc_counter aurora_hls_crc_counter_0 (
     .clk(user_clk),


### PR DESCRIPTION
Only the LSB of the frames_received and frames_with_errors counters provided by the aurora_hls_crc_counter module were wired up. All of our tests probably transferred an even number of frames, hence the counters were always showing up as 0 when read by the host code.

Output for the test case given in `scripts/run_N1.sh`:

```
3: Total frames received: 8388608
3: Frames with errors: 0
2: Total frames received: 8388608
2: Frames with errors: 0
1: Total frames received: 8388608
1: Frames with errors: 0
5: Total frames received: 8388608
5: Frames with errors: 0
4: Total frames received: 8388608
4: Frames with errors: 0
0: Total frames received: 8388608
0: Frames with errors: 0
```

Fixes #1