### PR TITLE
Software-controlled reset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ TARGET := hw
 INS_LOSS_NYQ := 8
 RX_EQ_MODE := LPM
 USE_FRAMING := 0
+DRAIN_AXI_ON_RESET := 1
 
 FIFO_WIDTH := 64
 RX_FIFO_DEPTH := 512
@@ -135,6 +136,9 @@ RTL_SRC_1 := $(RTL_SRC) ./rtl/aurora_hls_1.v ./xdc/aurora_64b66b_1.xdc
 	fi
 	if [ $(PROBE_CRC_COUNTER) = 1 ]; then \
 		echo "\`define PROBE_CRC_COUNTER" >> $@; \
+	fi
+	if [ $(DRAIN_AXI_ON_RESET) = 1 ]; then \
+		echo "\`define DRAIN_AXI_ON_RESET" >> $@; \
 	fi
 	echo "\`define HAS_TKEEP $(HAS_TKEEP)" >> $@
 	echo "\`define HAS_TLAST $(HAS_TKEEP)" >> $@

--- a/rtl/aurora_hls.v.template.v
+++ b/rtl/aurora_hls.v.template.v
@@ -161,6 +161,14 @@ wire            sw_reset;
 wire            ap_rst_n_core;
 assign ap_rst_n_core = ap_rst_n && !sw_reset;
 
+// optionally drain tx data source during sw_reset
+wire            tx_axis_tready_raw;
+`ifdef DRAIN_AXI_ON_RESET
+    assign tx_axis_tready = tx_axis_tready_raw || sw_reset;
+`else
+    assign tx_axis_tready = tx_axis_tready_raw;
+`endif
+
 aurora_hls_reset aurora_hls_reset_0 (
     .init_clk(init_clk),
     .ap_rst_n_i(ap_rst_n_i),
@@ -387,7 +395,7 @@ aurora_hls_io aurora_hls_io_0 (
 `endif
     .tx_axis_tdata(tx_axis_tdata),
     .tx_axis_tvalid(tx_axis_tvalid),
-    .tx_axis_tready(tx_axis_tready),
+    .tx_axis_tready(tx_axis_tready_raw),
 `ifdef USE_FRAMING
     .tx_axis_tlast(tx_axis_tlast),
     .tx_axis_tkeep(tx_axis_tkeep),

--- a/rtl/aurora_hls.v.template.v
+++ b/rtl/aurora_hls.v.template.v
@@ -156,6 +156,11 @@ wire             pma_init_i;
 wire            ap_rst_n_i;
 wire            ap_rst_n_u;
 
+// software-controllable reset
+wire            sw_reset;
+wire            ap_rst_n_core;
+assign ap_rst_n_core = ap_rst_n && !sw_reset;
+
 aurora_hls_reset aurora_hls_reset_0 (
     .init_clk(init_clk),
     .ap_rst_n_i(ap_rst_n_i),
@@ -164,13 +169,13 @@ aurora_hls_reset aurora_hls_reset_0 (
 );
 
 xpm_cdc_async_rst reset_sync_0 (
-    .src_arst   (ap_rst_n),
+    .src_arst   (ap_rst_n_core),
     .dest_clk   (init_clk),
     .dest_arst  (ap_rst_n_i)
 );
 
 xpm_cdc_async_rst reset_sync_1 (
-    .src_arst   (ap_rst_n),
+    .src_arst   (ap_rst_n_core),
     .dest_clk   (user_clk),
     .dest_arst  (ap_rst_n_u)
 );
@@ -364,7 +369,7 @@ aurora_64b66b_0 aurora_64b66b_0_0 (
 
 aurora_hls_io aurora_hls_io_0 (
     .ap_clk(ap_clk),
-    .ap_rst_n(ap_rst_n),
+    .ap_rst_n(ap_rst_n_core),
     .user_clk(user_clk),
     .ap_rst_n_u(ap_rst_n_u),
     .rx_axis_tdata(rx_axis_tdata),
@@ -479,11 +484,12 @@ aurora_hls_control_s_axi axi_control_slave (
   .aurora_status    (aurora_status),
   .fifo_status      (fifo_status),
   .configuration    (configuration),
-  .fifo_thresholds  (fifo_thresholds)
+  .fifo_thresholds  (fifo_thresholds),
 `ifdef USE_FRAMING
-, .frames_received  (frames_received),
-  .frames_with_errors (frames_with_errors)
+  .frames_received  (frames_received),
+  .frames_with_errors (frames_with_errors),
 `endif
+  .sw_reset         (sw_reset)
 );
 
 endmodule

--- a/rtl/aurora_hls_control_s_axi.v
+++ b/rtl/aurora_hls_control_s_axi.v
@@ -1,6 +1,7 @@
 //
-// Copyright 2022 Xilinx, Inc.
+// Copyright 2021-2022 Xilinx, Inc.
 //           2023-2024 Gerrit Pape (papeg@mail.upb.de)
+//           2023-2024 Paderborn Center for Parallel Computing
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -73,6 +74,12 @@ localparam
     ADDR_FRAMES_WITH_ERRORS = 12'h024,
 `endif
     
+    // registers write state machine
+    WRIDLE          = 2'd0,
+    WRDATA          = 2'd1,
+    WRRESP          = 2'd2,
+    WRRESET         = 2'd3,
+    
     // registers read state machine
     RDIDLE          = 2'd0,
     RDDATA          = 2'd1,
@@ -80,14 +87,73 @@ localparam
 
 //------------------------Signal Declaration----------------------
     // axi operation
+    reg  [1:0]      wstate;
+    reg  [1:0]      wnext;
+    reg  [11:0]     waddr;
+    wire [31:0]     wmask;
+    wire            aw_hs;
+    wire            w_hs;
     reg  [1:0]      rstate;
     reg  [1:0]      rnext;
     reg  [31:0]     rdata;
     wire            ar_hs;
     wire [11:0]     raddr;
-    
 
 //------------------------AXI protocol control------------------    
+    //------------------------AXI write fsm------------------
+    assign AWREADY = (wstate == WRIDLE);
+    assign WREADY  = (wstate == WRDATA);
+    assign BRESP   = 2'b00;  // OKAY
+    assign BVALID  = (wstate == WRRESP);
+    assign wmask   = { {8{WSTRB[3]}}, {8{WSTRB[2]}}, {8{WSTRB[1]}}, {8{WSTRB[0]}} };
+    assign aw_hs   = AWVALID & AWREADY;
+    assign w_hs    = WVALID & WREADY;
+
+    // wstate
+    always @(posedge ACLK) begin
+        if (!ARESETn)
+            wstate <= WRRESET;
+        else
+            wstate <= wnext;
+    end
+    
+    // wnext
+    always @(*) begin
+        case (wstate)
+            WRIDLE:
+                if (AWVALID)
+                    wnext = WRDATA;
+                else
+                    wnext = WRIDLE;
+            WRDATA:
+                if (WVALID)
+                    wnext = WRRESP;
+                else
+                    wnext = WRDATA;
+            WRRESP:
+                if (BREADY)
+                    wnext = WRIDLE;
+                else
+                    wnext = WRRESP;
+            default:
+                wnext = WRIDLE;
+        endcase
+    end
+    
+    // waddr
+    always @(posedge ACLK) begin
+        if (aw_hs)
+            waddr <= AWADDR;
+    end
+
+    // wdata
+    always @(posedge ACLK) begin
+        if (w_hs) begin
+            case (waddr)
+            endcase
+        end
+    end
+    
     //------------------------AXI read fsm-------------------
     assign ARREADY = (rstate == RDIDLE);
     assign RDATA   = rdata;
@@ -149,11 +215,5 @@ localparam
             endcase
         end
     end
-
-    // axi write channel tie-off
-    assign AWREADY = 1'b1;
-    assign WREADY  = 1'b1;
-    assign BRESP   = 2'b00;
-    assign BVALID  = 1'b0;
 
 endmodule


### PR DESCRIPTION
Start working on #10 by implementing the missing write logic in the AXI control interface

Most code is taken from https://github.com/Xilinx/Vitis-Tutorials/blob/dfc55741ecdb27e488cc5c82bdf1280c00463b98/Hardware_Acceleration/Design_Tutorials/05-bottom_up_rtl_kernel/krnl_aes/rtl/krnl_aes_axi_ctrl_slave.v which matches the read fsm that we already use here.

For now, introduce some crude testing by writing and reading a test register 1000 times. This can likely be removed in later commits.