### PR TITLE
Don't set a frame size when built without framing

### DIFF
--- a/host/host_aurora_hls_test.cpp
+++ b/host/host_aurora_hls_test.cpp
@@ -386,10 +386,6 @@ int main(int argc, char *argv[])
         wait_for_enter();
     }
 
-    // create kernel objects
-    IssueKernel issue(instance, device, xclbin_uuid, config);
-    DumpKernel dump(instance, device, xclbin_uuid, config);
-    
     Aurora aurora;
     if (!emulation) {
         aurora = Aurora(instance, device, xclbin_uuid);
@@ -398,6 +394,10 @@ int main(int argc, char *argv[])
             config.frame_size = 0; 
         }
     }
+
+    // create kernel objects
+    IssueKernel issue(instance, device, xclbin_uuid, config);
+    DumpKernel dump(instance, device, xclbin_uuid, config);
 
     double local_transmission_times[config.repetitions];
     for (uint32_t r = 0; r < config.repetitions; r++) {


### PR DESCRIPTION
In case the Aurora HLS core is built without framing, config.frame_size needs to be set to 0 before we initialize the issue kernel. Otherwise, the frame_size kernel argument will be set incorrectly, leading to degraded performance for small frame sizes (such as the default 1).

Before:
srun -n 6 -l ./host_aurora_hls_test -i 20
0: All correct, average throughput: 39.5697 Gbit/s

After:
srun -n 6 -l ./host_aurora_hls_test -i 20
0: All correct, average throughput: 96.6041 Gbit/s