### PR TITLE
Changeable TX FIFO settings in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ RX_FIFO_DEPTH := 512
 RX_FIFO_PROG_FULL := 384
 RX_FIFO_PROG_EMPTY := 128
 
+TX_FIFO_DEPTH := 128
+TX_FIFO_PROG_FULL := 96
+TX_FIFO_PROG_EMPTY := 32
+
 ifeq ($(USE_FRAMING), 1)
 	HAS_TKEEP := 1
 	HAS_TLAST := 1
@@ -68,7 +72,7 @@ PROBE_CRC_COUNTER := 1
 ./ip_creation/axis_data_fifo_tx/axis_data_fifo_tx.xci: ./tcl/create_fifo_ip.tcl
 	mkdir -p ip_creation
 	rm -rf ip_creation/axis_data_fifo_tx
-	vivado -mode batch -source $^ -tclargs $(PART) tx $(FIFO_WIDTH) 128 96 32 $(HAS_TKEEP) $(HAS_TLAST)
+	vivado -mode batch -source $^ -tclargs $(PART) tx $(FIFO_WIDTH) $(TX_FIFO_DEPTH) $(TX_FIFO_PROG_FULL) $(TX_FIFO_PROG_EMPTY) $(HAS_TKEEP) $(HAS_TLAST)
 
 ./ip_creation/axis_dwidth_converter_rx/axis_dwidth_converter_rx.xci: ./tcl/create_axis_dwidth_converter_ip.tcl
 	mkdir -p ip_creation

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ Using framing on this high line rate has stringent timing requirements. If you h
 The built-in flow control logic uses the programmable threshold status flags of the receiving FIFO to tell the sender side to stop transmission, when the full threshold is reached. The receiving side requests to start transmission again, when the empty threshold is reached. 
 
 The FIFO on the receiving side can be configured with the following options. The depth of the FIFO can be configured in powers of two ranging from 16 to 16384. The thresholds for programmable full and programmable empty can be any number, as long they are not too close to zero or completly full.
+This also applies to the TX set of variables, serving the same purpose for the transceiving side of the core.
 ```
-  make aurora RX_FIFO_DEPTH=512 RX_FIFO_PROG_FULL=384 RX_FIFO_PROG_EMPTY=128
+  make aurora RX_FIFO_DEPTH=512 RX_FIFO_PROG_FULL=384 RX_FIFO_PROG_EMPTY=128 TX_FIFO_DEPTH=128 TX_FIFO_PROG_FULL=96 TX_FIFO_PROG_EMPTY=32
 ```
 
 The distance between full and programmable full should be large enough to catch the values, which are still transmitted, so no transmissions are lost. The distance between empty and programmable empty should be large enough, so the FIFO does not run empty while waiting for receiving new data. In the test setup on Noctua2 there are a maximum of 150 transmissions, which corresponds to a FIFO depth of 75. If you want to verify this for your setup you can enable a integrated logic analyzer for the NFC module, which also probes the valid signal of the receiving side, to count the number of transmissions. Pay attention that the valid signal after the datawidth converter is used, because probing the valid signal of the aurora core itself is very difficult to route. With the regular setup of a FIFO width of 64 bytes, one transmission after the datawidth converter corresponds to two transmissions with the aurora core, which has a width of 32 bytes.


### PR DESCRIPTION
Add variables to adapt the TX FIFO settings in the Makefile as well. By default set to the previously hardcoded values.