### PR TITLE
Added Aurora version parameter to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ BUILD_DIR       ?= $(AURORA_FLOW_DIR)/build
 
 all: aurora_hw aurora_hw_emu aurora_sw_emu
 
+# Aurora IP Core Version
+AURORA_VERSION ?= 12.0
+
 # Target board
 PART     := xcu280-fsvh2892-2L-e
 PLATFORM ?= xilinx_u280_gen3x16_xdma_1_202211_1
@@ -79,7 +82,7 @@ $(BUILD_DIR):
 $(BUILD_DIR)/ip_creation/aurora_64b66b_0/aurora_64b66b_0.xci: $(AURORA_FLOW_DIR)/tcl/create_aurora_ip.tcl | $(BUILD_DIR)
 	mkdir -p $(BUILD_DIR)/ip_creation
 	rm -rf $(BUILD_DIR)/ip_creation/aurora_64b66b_0
-	cd $(BUILD_DIR) && vivado -mode batch -source $< -tclargs $(PART) 0 $(INS_LOSS_NYQ) $(RX_EQ_MODE) $(USE_FRAMING)
+	cd $(BUILD_DIR) && vivado -mode batch -source $< -tclargs $(PART) 0 $(INS_LOSS_NYQ) $(RX_EQ_MODE) $(USE_FRAMING) $(AURORA_VERSION)
 
 $(BUILD_DIR)/ip_creation/axis_data_fifo_rx/axis_data_fifo_rx.xci: $(AURORA_FLOW_DIR)/tcl/create_fifo_ip.tcl | $(BUILD_DIR)
 	mkdir -p $(BUILD_DIR)/ip_creation

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ All parameters are also forwarded automatically when the library is built throug
 | `TX_FIFO_SIZE`        | `8192`  | TX FIFO size in bytes |
 | `PART`                | `xcu280-fsvh2892-2L-e` | Target device part |
 | `PLATFORM`            | `xilinx_u280_gen3x16_xdma_1_202211_1` | Target platform |
+| `VERSION`             | `12.0`  | Aurora IP Core Version |
 
 ### FIFO configuration
 

--- a/aurora_flow.mk
+++ b/aurora_flow.mk
@@ -73,6 +73,9 @@ endif
 ifdef DRAIN_AXI_ON_RESET
   AURORA_FLOW_MAKE_ARGS += DRAIN_AXI_ON_RESET=$(DRAIN_AXI_ON_RESET)
 endif
+ifdef AURORA_VERSION
+  AURORA_FLOW_MAKE_ARGS += AURORA_VERSION=$(AURORA_VERSION)
+endif
 
 .PHONY: aurora_flow_hw aurora_flow_hw_emu aurora_flow_sw_emu
 

--- a/tcl/create_aurora_ip.tcl
+++ b/tcl/create_aurora_ip.tcl
@@ -23,6 +23,8 @@ set rx_eq_mode [lindex $argv 3]
 
 set use_framing [lindex $argv 4]
 
+set version [lindex $argv 5]
+
 if {$use_framing == "1"} {
     set interface_mode "Framing"
     set crc_mode "true"
@@ -38,7 +40,7 @@ if {$use_framing == "1"} {
 create_ip -name aurora_64b66b \
           -vendor xilinx.com \
           -library ip \
-          -version 12.0 \
+          -version $version \
           -module_name aurora_64b66b_$instance \
           -dir ./ip_creation
 


### PR DESCRIPTION
From what I can gather on the official Docs (https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/aurora64b66b.html#tabs-46a5472a1a-item-10fdd6e511-tab), the Aurora IP Core is version-locked with the used Vivado version. To accommodate newer tool versions, I added a version parameter, defaulting to `12.0`, which is settable during the make call: `make AURORA_VERSION=...`. 

I left the default at `12.0`, since many tool versions match this IP version, and only recent releases seem to switch to `13.0`.